### PR TITLE
fix: errors when empty items and songplay is NaN

### DIFF
--- a/app/util.py
+++ b/app/util.py
@@ -57,10 +57,11 @@ class SpotifyUtil:
                 json_items = getattr(self.session, "playlist_items")(
                     limit=100, playlist_id=self.df.at[index, "playlist_id"]
                 )
-                playlist_items, columns = getattr(
-                    self, self.query_dict["playlist_items"]
-                )(data=json_items, playlist_id=self.df.at[index, "playlist_id"])
-                items.append(playlist_items)
+                if len(json_items['items']) > 0:
+                    playlist_items, columns = getattr(
+                        self, self.query_dict["playlist_items"]
+                    )(data=json_items, playlist_id=self.df.at[index, "playlist_id"])
+                    items.append(playlist_items)
 
             df_items = pd.concat(items, ignore_index=True)
             return self.df, df_items
@@ -94,6 +95,8 @@ class SpotifyUtil:
         if not (kwargs.get("result_key") == None):
             data = data[kwargs["result_key"]]
         df = pd.json_normalize(data).reset_index()
+        if "id" in columns:
+            df = df.dropna(subset = ["id"])
         df["index"] = df["index"] + 1
         df = df[columns.keys()].rename(columns=columns)
         return df


### PR DESCRIPTION
### Fixed the following errors

```
Traceback (most recent call last):
  File "app/main.py", line 55, in <module>
    main()
  File "app/main.py", line 34, in main
    df, df_items = spotifyutil.get_spotify_data(query=query, limit=ITEM_LIMIT)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 60, in get_spotify_data
    playlist_items, columns = getattr(
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 306, in parse_playlists_items
    playlist_items = self.parse_tracks(data=data)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 277, in parse_tracks
    top_tracks = self.parse_songplays(data=data, columns=columns)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 133, in parse_songplays
    songplays = self.parse_json(data=data, columns=columns, result_key="items")
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 98, in parse_json
    df = df[columns.keys()].rename(columns=columns)
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/frame.py", line 3461, in __getitem__
    indexer = self.loc._get_listlike_indexer(key, axis=1)[1]
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/indexing.py", line 1314, in _get_listlike_indexer
    self._validate_read_indexer(keyarr, indexer, axis)
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/indexing.py", line 1377, in _validate_read_indexer
    raise KeyError(f"{not_found} not in index")
KeyError: "['id', 'name', 'artists', 'duration_ms', 'explicit', 'popularity', 'album.id', 'album.name', 'album.release_date', 'album.type'] not in index"
make: *** [Makefile:9: run] Erro 1
```

```Traceback (most recent call last):
  File "app/main.py", line 55, in <module>
    main()
  File "app/main.py", line 34, in main
    df, df_items = spotifyutil.get_spotify_data(query=query, limit=ITEM_LIMIT)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 61, in get_spotify_data
    playlist_items, columns = getattr(
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 307, in parse_playlists_items
    playlist_items = self.parse_tracks(data=data)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 278, in parse_tracks
    top_tracks = self.parse_songplays(data=data, columns=columns)
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 152, in parse_songplays
    ) = zip(*songplays["artists"].apply(parse_artist))
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/series.py", line 4356, in apply
    return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/apply.py", line 1036, in apply
    return self.apply_standard()
  File "/www/coks/dbt-spotify-analytics/venv/lib/python3.8/site-packages/pandas/core/apply.py", line 1092, in apply_standard
    mapped = lib.map_infer(
  File "pandas/_libs/lib.pyx", line 2859, in pandas._libs.lib.map_infer
  File "/www/coks/dbt-spotify-analytics/app/util.py", line 140, in parse_artist
    [artist["name"] for artist in artists]
TypeError: 'float' object is not iterable
make: *** [Makefile:9: run] Erro 1
```
